### PR TITLE
Correct spelling of Luminance in AppSettings.json

### DIFF
--- a/config/appsettings.json
+++ b/config/appsettings.json
@@ -8,7 +8,7 @@
     "RelativeDarkLuminanceThreshold": 0.8,
     "CdLuminanceFlashThreshold": 20, //flash transition
     "CdDarkLuminanceThreshold": 160,
-    //possible CD luminanve values for look up table
+    //possible CD luminance values for look up table
     "CdLuminanceValues": [
       0.07,
       0.09,


### PR DESCRIPTION
In response to issue #5 